### PR TITLE
fix: Update sitemap and robots.js for better SEO

### DIFF
--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -3,8 +3,8 @@ export default function robots() {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/api/', '/admin/'],
+      disallow: ['/api/', '/admin/', '/studio/'],
     },
     sitemap: 'https://thedebuthub.com/sitemap.xml',
   };
-} 
+}

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -3,23 +3,25 @@ export default function sitemap() {
   const now = new Date();
   
   return [
+    // Main pages
     {
       url: baseUrl,
       lastModified: now,
-      changeFrequency: 'daily',
+      changeFrequency: 'hourly', // Changed to hourly since we have 3-minute data refresh
       priority: 1.0,
     },
+    // Articles section
     {
-      url: `${baseUrl}/api/spotify/albums/most-streamed`,
+      url: `${baseUrl}/articles`,
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.8,
     },
-    {
-      url: `${baseUrl}/api/spotify/tracks`,
-      lastModified: now,
-      changeFrequency: 'daily',
-      priority: 0.8,
-    },
+    // Note: Individual article pages would need to be dynamically generated
+    // from your CMS/database. For now, search engines will discover them
+    // through internal links from the articles index page.
+    
+    // Admin pages (excluded from indexing via robots meta tag)
+    // Not including /admin and /studio as they should not be indexed
   ];
-} 
+}


### PR DESCRIPTION
- Updated sitemap to remove deprecated API endpoints
- Changed homepage frequency to 'hourly' (matches 3-minute data refresh)
- Added /articles page to sitemap
- Updated robots.js to also exclude /studio/ from crawling
- Improved comments for better documentation